### PR TITLE
enable remote debugging in content service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,7 @@ services:
     ports:
       - "8110:8080"
       - "9110:9990"
+      - "8787:8787"  # for remote debugging
     volumes:
       - /oli/content/course_content_xml:/oli/course_content_xml
       - /oli/content/course_content_volume:/oli/course_content_volume

--- a/wildfly-mysql/execute.sh
+++ b/wildfly-mysql/execute.sh
@@ -7,4 +7,4 @@ $JBOSS_HOME/bin/add-user.sh -up mgmt-users.properties $adminuser $adminpass --si
 echo "=> Stating WildFly"
 # -Dcom.sun.management.jmxremote.rmi.port=9090 -Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.port=9090 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.local.only=false -Djava.rmi.server.hostname=128.237.202.186
 
-$JBOSS_HOME/bin/standalone.sh -b 0.0.0.0 -bmanagement 0.0.0.0
+$JBOSS_HOME/bin/standalone.sh -b 0.0.0.0 -bmanagement 0.0.0.0 --debug


### PR DESCRIPTION
As long as the editor-base docker-compose.yml is only used for development environments, this should not affect ports exposed in production.

You will have to clear and rebuild your images from scratch (specifically, jboss/wildfly -> olisimon/wildfly -> oli/content-service)

To use, simply configure your Java IDE (e.g. intellij) for remote debugging with host "dev.local" and port "8787"