### PR TITLE
serve dist files

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,13 +69,14 @@ services:
       - ../course-editor:/app
       - ../course-editor/dist:/app/dist
       - /app/node_modules
-    command: gulp dev
+    command: npm run dev
   nginx:
     build: ./nginx
     image: oli/nginx
     container_name: oli-nginx
     volumes:
       - /oli/content/webcontent:/oli/webcontent/webcontents
+      - ../course-editor/dist:/oli/course-editor/dist
     networks:
       - service-tier
   dev.local:

--- a/ha-proxy/haproxy.cfg
+++ b/ha-proxy/haproxy.cfg
@@ -13,7 +13,7 @@ frontend http-in
     #bind *:443 ssl crt /certs/combined.pem
     #redirect scheme https if !{ ssl_fc }
     #reqadd X-Forwarded-Proto:\ https
-    acl nginx_path  path_beg /content-swagger /webcontents
+    acl nginx_path  path_beg /content-swagger /webcontents /dist
     acl content_path  path_beg /content-service/
     acl keycloak_path  path_beg /auth/
 

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,5 +1,6 @@
 FROM nginx:alpine
 RUN mkdir -p /oli/webcontent/webcontents
+RUN mkdir -p /oli/course-editor/dist
 RUN mkdir /usr/share/nginx/html/content-swagger
 COPY ./default.conf /etc/nginx/conf.d
 COPY ./content-swagger/ /usr/share/nginx/html/content-swagger/

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -14,6 +14,16 @@ server {
         root   /oli/webcontent;
     }
 
+    location ^~ /dist/index.html {
+        root   /oli/course-editor;
+        add_header 'Cache-Control' 'no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0';
+	    expires off;
+    }
+
+    location ^~ /dist {
+        root   /oli/course-editor;
+    }
+
     #error_page  404              /404.html;
 
     # redirect server error pages to the static page /50x.html


### PR DESCRIPTION
Changes our development docker config to:

1) Use the npm script instead of gulp for launching webpack-dev-server
2) Wires in the course-editor/dist directory to be served statically from nginx. This allows us to test dist changes locally via http://dev.local/dist/index.html