### PR TITLE
increased  max size of mysql queries

### DIFF
--- a/mysql/simon.cnf
+++ b/mysql/simon.cnf
@@ -1,2 +1,3 @@
 [mysqld]
 transaction_isolation=READ-COMMITTED
+max_allowed_packet=128M


### PR DESCRIPTION
The 16mb default max packet size for Mysql is insufficient for some course content import. This addresses that current limitation.