### PR TITLE
Authoring 2327 keycloak theme for new user communications

### DIFF
--- a/keycloak-mysql/oli_security-realm.json
+++ b/keycloak-mysql/oli_security-realm.json
@@ -1,7 +1,7 @@
 {
   "id" : "oli_security",
   "realm" : "oli_security",
-  "displayName" : "OLI Security",
+  "displayName" : "OLI Echo",
   "notBefore" : 1540228919,
   "revokeRefreshToken" : false,
   "refreshTokenMaxReuse" : 0,
@@ -3299,7 +3299,7 @@
     "_browser_header.strictTransportSecurity" : "max-age=31536000; includeSubDomains",
     "_browser_header.xFrameOptions" : "SAMEORIGIN",
     "quickLoginCheckMilliSeconds" : "1000",
-    "displayName" : "OLI Security",
+    "displayName" : "OLI Echo",
     "_browser_header.xRobotsTag" : "none",
     "maxFailureWaitSeconds" : "900",
     "minimumQuickLoginWaitSeconds" : "60",

--- a/keycloak-mysql/themes/oli_theme/email/messages/messages_en.properties
+++ b/keycloak-mysql/themes/oli_theme/email/messages/messages_en.properties
@@ -1,0 +1,3 @@
+emailVerificationSubject=OLI Echo: Verify email
+emailVerificationBody=An {2} account with this email address has been created. If this was you, click the link below to verify your email address\n\n{0}\n\nThis link will expire within {3}.\n\nIf you didn''t create this account, just ignore this message.
+emailVerificationBodyHtml=<p>An {2} account with this email address has been created. If this was you, click the link below to verify your email address</p><p><a href="{0}">Link to e-mail address verification</a></p><p>This link will expire within {3}.</p><p>If you didn''t create this account, just ignore this message.</p>

--- a/keycloak-mysql/themes/oli_theme/email/theme.properties
+++ b/keycloak-mysql/themes/oli_theme/email/theme.properties
@@ -1,0 +1,1 @@
+parent=base

--- a/keycloak-mysql/themes/oli_theme/login/resources/css/login.css
+++ b/keycloak-mysql/themes/oli_theme/login/resources/css/login.css
@@ -106,10 +106,11 @@ div.kc-logo-text span {
 
 #kc-header-wrapper {
     font-size: 29px;
+    font-weight: bold;
     text-transform: uppercase;
     letter-spacing: 3px;
     line-height: 1.2em;
-    padding: 62px 10px 20px;
+    padding: 130px 10px 20px;
     white-space: normal;
 }
 

--- a/keycloak-mysql/themes/oli_theme/login/template.ftl
+++ b/keycloak-mysql/themes/oli_theme/login/template.ftl
@@ -35,7 +35,7 @@
   <div class="${properties.kcLoginClass!}">
     <div id="kc-header" class="${properties.kcHeaderClass!}">
         <div id="kc-logo-wrapper"/>
-      <#--<div id="kc-header-wrapper" class="${properties.kcHeaderWrapperClass!}">${kcSanitize(msg("loginTitleHtml",(realm.displayNameHtml!'')))?no_esc}</div>-->
+        <div id="kc-header-wrapper" class="${properties.kcHeaderWrapperClass!}">${kcSanitize(msg("loginTitleHtml",(realm.displayNameHtml!'')))?no_esc}</div>
     </div>
     <div class="${properties.kcFormCardClass!} <#if displayWide>${properties.kcFormCardAccountClass!}</#if>">
       <header class="${properties.kcFormHeaderClass!}">


### PR DESCRIPTION
This installs small keycloak theme changes to support clearer new user communications. After deploying, requires making the following changes in the Keycloak Admin console to activate. This may not be needed in a development environment.

Realm Settings/General:
Display Name: OLI Echo
HTML Display Name: <p>OLI Echo<p>
Themes:
Email theme: oli_theme
Email:
From Display Name: OLI Echo

This will change the realm display name from the unclear "OLI Security" to "OLI Echo" in all communications, include "OLI Echo" on the login/register page, and adjust the new account verification email to show it comes from OLI Echo.